### PR TITLE
mcq-network-pftable: fixed typo

### DIFF
--- a/book-2nd/mcq-ex/mcq-network-pftables.rst
+++ b/book-2nd/mcq-ex/mcq-network-pftables.rst
@@ -147,7 +147,7 @@ Port forwarding tables are used in tree-shaped networks to automatically build t
       Dest.   OutPort 
       ======  ========
       A       W 
-      B       S 
+      B       E 
       ======  ========
 
    .. negative::    


### PR DESCRIPTION
The second OutPort of R1 is at the East.

Note: about the previous one:

> Upon reception of this packet, the port forwarding table of `R3` will be updated as :
> 
> ```
>  ======  ========
>  Dest.   OutPort 
>  ======  ========
>  A       N 
>  B       E 
>  ======  ========
> ```

I guess it's wrong too but I don't know how to fix it: by adding an edge between `R3` and `B`?
