### PR TITLE
[FIX] Signal handlers can only use async-safe functions

### DIFF
--- a/book-2nd/exercises/c/tlv_ex.c
+++ b/book-2nd/exercises/c/tlv_ex.c
@@ -108,7 +108,12 @@ int main(int ac, char **av)
      * "[-] Timeout" then exit.
      */
     if (setjmp(timeout_jump) == 1) {
-        printf("[-] Timeout\n");
+        /* This code is executed within the signal handler, it can only call
+         * async-safe functions i.e. NOT printf(3).
+         * See signal(7) for a list of allowed functions.
+         */
+        const char timeout_str[] = "[-] Timeout\n";
+        write(STDOUT_FILENO, timeout_str, sizeof(timeout_str));
         return 1;
     }
 


### PR DESCRIPTION
Calling longjmp starts executes the code following the most recent setjmp in the current context, which in this case means in the context of a signal handler. As such the code that is executed must be async-signal-safe (as in signal(7)) because it can be interrupted by other signals.
