### PR TITLE
mcp-ipv6: Q1: fixed typo

### DIFF
--- a/book-2nd/mcq-ex/mcq-ipv6.rst
+++ b/book-2nd/mcq-ex/mcq-ipv6.rst
@@ -59,7 +59,7 @@ Multiple choice questions
 
    .. negative:: ``2001:db8:a:bb::cc:ddd::1``
 
-      ..comment:: This address is invalid. An IPv6 address cannot contain twice two consecutive semicolumns ``::``
+      .. comment:: This address is invalid. An IPv6 address cannot contain twice two consecutive semicolumns ``::``
 
    .. positive:: ``2001:db8:1234:1234:1234:5678::1``
 


### PR DESCRIPTION
Hello,

A whitespace was missing and then the comment was visible before having validated the form.

Regards,

Matthieu
