### PR TITLE
mcq-ipv6: Q2: removed an extra semi-column

### DIFF
--- a/book-2nd/mcq-ex/mcq-ipv6.rst
+++ b/book-2nd/mcq-ex/mcq-ipv6.rst
@@ -89,7 +89,7 @@ Multiple choice questions
 
    .. positive::  ``2001:0db8:0000:0000:000a::cafe``
 
-   .. positive::  ``2001:0db8::a::0:0:cafe``
+   .. positive::  ``2001:0db8::a:0:0:cafe``
 
    .. negative::  ``2001:0db8::a::cafe``
 


### PR DESCRIPTION
Hello,

This commit fixes #116 (there was an extra semi-column).

Thanks to @natashakth

Regards,

Matthieu
