### PR TITLE
mcq-ipv6: R3: East and not West interface

### DIFF
--- a/book-2nd/mcq-ex/mcq-ipv6.rst
+++ b/book-2nd/mcq-ex/mcq-ipv6.rst
@@ -113,7 +113,7 @@ The routers have one address inside each network :
 
  - router ``R1`` uses address ``2001:db8:1341:1::1`` on its West interface, address ``2001:db8:1341:12::1`` on its East interface and address ``2001:db8:1341:13::1`` on its South interface
  - router ``R2`` uses address ``2001:db8:1341:12::2`` on its West interface and address ``2001:db8:1341:23::2`` on its South-West interface 
- - router ``R3`` uses address ``2001:db8:1341:3::3`` on its West interface, address ``2001:db8:1341:23::3`` on its North-East interface and address ``2001:db8:1341:13::3`` on its North interface
+ - router ``R3`` uses address ``2001:db8:1341:3::3`` on its East interface, address ``2001:db8:1341:23::3`` on its North-East interface and address ``2001:db8:1341:13::3`` on its North interface
 
 The forwarding tables of these three routers, ignoring the routes to the local interfaces, are shown in the figure below.
 
@@ -260,7 +260,7 @@ The routers have one address inside each network :
 
  - router ``R1`` uses address ``2001:db8:1341:1::1`` on its West interface, address ``2001:db8:1341:12::1`` on its East interface and address ``2001:db8:1341:13::1`` on its South interface
  - router ``R2`` uses address ``2001:db8:1341:12::2`` on its West interface, address ``2001:db8:1341:23::2`` on its South-West interface and address ``2001:db8:1341:24::2`` on its South interface.
- - router ``R3`` uses address ``2001:db8:1341:34::3`` on its West interface, address ``2001:db8:1341:23::3`` on its North-East interface and address ``2001:db8:1341:13::3`` on its North interface
+ - router ``R3`` uses address ``2001:db8:1341:34::3`` on its East interface, address ``2001:db8:1341:23::3`` on its North-East interface and address ``2001:db8:1341:13::3`` on its North interface
  - router ``R4`` uses address ``2001:db8:1341:34::4`` on its West interface, address ``2001:db8:1341:24::4`` on its North interface and address ``2001:db8:1341:4::4`` on its East interface
 
 The forwarding paths used in a network depend on the forwarding tables installed in the network nodes. Sometimes, these forwarding tables must be configured manually. 
@@ -598,7 +598,7 @@ The routers have one address inside each network :
 
  - router ``R1`` uses address ``2001:db8:1341:1::1`` on its West interface, address ``2001:db8:1341:12::1`` on its East interface and address ``2001:db8:1341:13::1`` on its South interface
  - router ``R2`` uses address ``2001:db8:1341:12::2`` on its West interface and address ``2001:db8:1341:23::2`` on its South-West interface 
- - router ``R3`` uses address ``2001:db8:1341:3::3`` on its West interface, address ``2001:db8:1341:23::3`` on its North-East interface and address ``2001:db8:1341:13::3`` on its North interface
+ - router ``R3`` uses address ``2001:db8:1341:3::3`` on its East interface, address ``2001:db8:1341:23::3`` on its North-East interface and address ``2001:db8:1341:13::3`` on its North interface
 
 The forwarding tables of these three routers, ignoring the routes to the local interfaces, are shown in the figure below.
 
@@ -826,7 +826,7 @@ The routers have one address inside each network :
 
  - router ``R1`` uses address ``2001:db8:1341:1::1`` on its West interface, address ``2001:db8:1341:12::1`` on its East interface and address ``2001:db8:1341:13::1`` on its South interface
  - router ``R2`` uses address ``2001:db8:1341:12::2`` on its West interface, and address ``2001:db8:1341:24::2`` on its South interface
- - router ``R3`` uses address ``2001:db8:1341:34::3`` on its West interface and address ``2001:db8:1341:13::3`` on its North interface
+ - router ``R3`` uses address ``2001:db8:1341:34::3`` on its East interface and address ``2001:db8:1341:13::3`` on its North interface
  - router ``R4`` uses address ``2001:db8:1341:34::4`` on its West interface, address ``2001:db8:1341:24::4`` on its North interface and address ``2001:db8:1341:4::4`` on its East interface
 
 Routers ``R2`` and ``R3`` are buggy in this network. Besides the routes for their local interfaces (not shown in the figure), they only have a default route which is shown in the figure below.
@@ -904,7 +904,7 @@ The routers have one address inside each network :
 
  - router ``R1`` uses address ``2001:db8:1341:1::1`` on its West interface, address ``2001:db8:1341:12::1`` on its East interface, address ``2001:db8:1341:14::1`` on its South-East interface and address ``2001:db8:1341:13::1`` on its South interface
  - router ``R2`` uses address ``2001:db8:1341:12::2`` on its West interface, and address ``2001:db8:1341:24::2`` on its South interface
- - router ``R3`` uses address ``2001:db8:1341:34::3`` on its West interface and address ``2001:db8:1341:13::3`` on its North interface
+ - router ``R3`` uses address ``2001:db8:1341:34::3`` on its East interface and address ``2001:db8:1341:13::3`` on its North interface
  - router ``R4`` uses address ``2001:db8:1341:34::4`` on its West interface, address ``2001:db8:1341:24::4`` on its North interface, address ``2001:db8:1341:14::4`` on its North-West interface and address ``2001:db8:1341:4::4`` on its East interface
 
  Can you configure the forwarding tables so that the following paths are used by packets sent by host ``A`` to reach one of the four addresses of router ``R4``?


### PR DESCRIPTION
Hello,

This commit fixes #115 (East and not West interface).
Compared to students, we can see that the professor is not used to managing copy/paste :smile: 

Thanks to @natashakth

Regards,

Matthieu
