### PR TITLE
ex-routing-policies: fixed typo and verbatim

### DIFF
--- a/book-2nd/exercises/ex-routing-policies.rst
+++ b/book-2nd/exercises/ex-routing-policies.rst
@@ -98,7 +98,7 @@ Once the interdomain network has fully converged, analyze the consequence of a f
 
  In this internet, some ASes cannot reach all other ASes. Can you fix the problem by adding one shared-cost peering link or one customer-provider peering link ?
 
-5. Consider the network below in which a stub domain, `AS456`, is connected to two providers `AS123` and `AS789`. `AS456` advertises its prefix to both its providers. On the other hand, `AS123` advertises `2001:db8:dead://48` while `AS789` advertises `2001:db8:beef::/48` and `2001:db8:dead:cafe::/63`. Via which provider will the packets destined to ``2001:db8:dead:cafe::1`` will be received by `AS456` ?
+5. Consider the network below in which a stub domain, `AS456`, is connected to two providers `AS123` and `AS789`. `AS456` advertises its prefix to both its providers. On the other hand, `AS123` advertises ``2001:db8:dead::/48`` while `AS789` advertises ``2001:db8:beef::/48`` and ``2001:db8:dead:cafe::/63``. Via which provider will the packets destined to ``2001:db8:dead:cafe::1`` will be received by `AS456` ?
 
   .. figure:: fig/ex-bgp-stub-two-providers.png
      :align: center


### PR DESCRIPTION
Hello,

IPv6 addresses were not in verbatim mode
And fixed one typo: `://` instead of `::/`

Regards,

Matthieu
