### PR TITLE
Update network-stp.rst

### DIFF
--- a/book-2nd/mcq-ex/network-stp.rst
+++ b/book-2nd/mcq-ex/network-stp.rst
@@ -134,13 +134,13 @@ The third information contains two parts : the identifier of the switch that sen
 
    Which of the following affirmations about the state of the ports of switch ``32`` is correct ? 
 
-   .. positive:: The port towards switch ``25`` is the `root port` of the switch and the ports towards switches ``42``, ``19`` and ``46`` are `blocked`. 
+   .. negative:: The port towards switch ``25`` is the `root port` of the switch and the ports towards switches ``42``, ``19`` and ``46`` are `blocked`. 
 
    .. negative:: The port towards switch ``25`` is the `root port` of the switch. The ports towards switch ``19`` is `blocked` and the ports towards switches ``42`` and ``46`` are `designated`. 
 
    .. negative:: The port towards switch ``19`` is the `root port` of the switch. The ports towards switch ``46`` is `blocked` and the ports towards switches ``42`` and ``25`` are `designated`. 
 
-   .. negative:: The port towards switch ``25`` is the `root port` of the switch. The ports towards switches ``46``, ``42`` and ``25`` are `designated`. 
+   .. positive:: The port towards switch ``25`` is the `root port` of the switch. The ports towards switches ``46``, ``42`` and ``19`` are `designated`. 
 
 
 4. Consider the switched network shown in the figure below.


### PR DESCRIPTION
Switch 32 has BDPU : [R=9, C=6, T=32.?] which is better than [R=9,C=7,T=19.2] because of the cost 6<7 (cost = 7 because 6 in the received BPDU but +1 for the link). 
For [R=9,C=12,T=42.1], cost : 6 < 12 thus the port towards switch 42 is designated. 
For [R=9,C=5,T=46.3], costs are equal with switch 32 BPDU cost but, T=32 < T=46 so the port towards 46 si also designated. 
Thus the answer should be all the ports are designated.
