### PR TITLE
fix #188 : Missing figures in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,6 +77,7 @@ Vagrant.configure(2) do |config|
      sudo apt-get install dvipng
      sudo apt-get install texlive-fonts-recommended
      sudo apt-get install -y poppler-utils
+     sudo apt-get install -y inkscape
      sudo easy_install -U sphinxcontrib-mscgen
      sudo easy_install -U sphinxcontrib-tikz
      # for tikz

--- a/book-2nd/Makefile-images
+++ b/book-2nd/Makefile-images
@@ -1,8 +1,9 @@
 #
 # OB
 #
-SUBDIRS = intro/svg intro/pkt application/svg application/pkt transport/pkt transport/svg network/pkt network/svg lan/pkt lan/svg
-     
+DIRS = intro/svg intro/pkt application/svg application/pkt transport/pkt transport/svg network/pkt network/svg lan/pkt lan/svg
+SUBDIRS := $(addprefix ../book/, $(DIRS))
+  
 subdirs:
 	for dir in $(SUBDIRS); do \
                $(MAKE) -C $$dir; \

--- a/book/util/cleansvg.sh
+++ b/book/util/cleansvg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-if [ `uname -s`, "Darwin" ]; then
+if [ `uname -s` = "Darwin" ]; then
 	INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
 else
 	INKSCAPE=`which inkscape`

--- a/book/util/cleansvg.sh
+++ b/book/util/cleansvg.sh
@@ -1,5 +1,10 @@
 #!/bin/bash 
-INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
+if [ `uname -s`, "Darwin" ]; then
+	INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
+else
+	INKSCAPE=`which inkscape`
+fi
+
 SCOUR=~obo/local/bin/scour.py 
 
 

--- a/book/util/convert.sh
+++ b/book/util/convert.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ `uname -s`, "Darwin" ]; then
+if [ `uname -s` = "Darwin" ]; then
 	INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
 else
 	INKSCAPE=`which inkscape`

--- a/book/util/convert.sh
+++ b/book/util/convert.sh
@@ -1,8 +1,9 @@
-#!/bin/bash 
-#on Ubuntu
-INKSCAPE=/usr/bin/inkscape
-#On MacOSX
-#INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
+#!/bin/bash
+if [ `uname -s`, "Darwin" ]; then
+	INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
+else
+	INKSCAPE=`which inkscape`
+fi
 
 if [ "${1##*.}" = "svg" ]
 then
@@ -17,9 +18,9 @@ then
  echo "Dimensions " ${W} "x" ${H}
  if [ ${W} -gt 500 ] 
  then
-       ${INKSCAPE} ${1} --export-width=1000 --export-area-snap --export-area-drawing --export-png=${DIRNAME}/${BASENAME}.png
+       ${INKSCAPE} ${1} --export-width=500 --export-area-snap --export-area-drawing --export-png=${DIRNAME}/${BASENAME}.png
        ${INKSCAPE} ${1} --export-width=500 --export-area-snap --export-area-drawing --export-pdf=${DIRNAME}/${BASENAME}.pdf
-       sips --resampleWidth 500 ${DIRNAME}/${BASENAME}.png
+#       sips --resampleWidth 500 ${DIRNAME}/${BASENAME}.png
 #       sips --resampleWidth 1000 ${DIRNAME}/${BASENAME}.pdf
  else
        #echo "Dimensions " ${W} "x" ${H}

--- a/book/util/convertpkt.sh
+++ b/book/util/convertpkt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-if [ `uname -s`, "Darwin" ]; then
+if [ `uname -s` = "Darwin" ]; then
 	INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
 else
 	INKSCAPE=`which inkscape`

--- a/book/util/convertpkt.sh
+++ b/book/util/convertpkt.sh
@@ -1,5 +1,9 @@
 #!/bin/bash 
-INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
+if [ `uname -s`, "Darwin" ]; then
+	INKSCAPE=/Applications/Inkscape.app/Contents/Resources/bin/inkscape
+else
+	INKSCAPE=`which inkscape`
+fi
 
 if [ "${1##*.}" = "svg" ]
 then
@@ -14,9 +18,9 @@ then
  echo "Dimensions " ${W} "x" ${H}
  if [ ${W} -gt 500 ] 
  then
-       ${INKSCAPE} ${1} --export-width=1000 --export-area-drawing --export-png=${DIRNAME}/${BASENAME}.png
+       ${INKSCAPE} ${1} --export-width=500 --export-area-drawing --export-png=${DIRNAME}/${BASENAME}.png
        ${INKSCAPE} ${1} --export-width=500 --export-area-drawing --export-pdf=${DIRNAME}/${BASENAME}.pdf
-       sips --resampleWidth 500 ${DIRNAME}/${BASENAME}.png
+#       sips --resampleWidth 500 ${DIRNAME}/${BASENAME}.png
 #       sips --resampleWidth 1000 ${DIRNAME}/${BASENAME}.pdf
  else
        #echo "Dimensions " ${W} "x" ${H}


### PR DESCRIPTION
Fix the missing figures generating with inkscape which has been
half-assed by #187.
Update Vagrantfile with the unix port of inkscape.
Update Makefile-images for entering the correct directories.