### PR TITLE
Missing figures introduced in the second edition

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,31 +66,30 @@ Vagrant.configure(2) do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
      sudo apt-get update
-     sudo apt-get install -y inkscape
-     sudo apt-get install -y python-sphinx
-     sudo apt-get install -y make
-     sudo apt-get install -y python-setuptools
-     sudo apt-get install -y mscgen
-     sudo apt-get install -y graphviz
-     sudo apt-get install -y texlive
-     sudo apt-get install -y texlive-pictures
-     sudo apt-get install -y texlive-latex-extra
-     sudo apt-get install -y dvipng
-     sudo apt-get install -y texlive-fonts-recommended
-     sudo apt-get install -y poppler-utils
-     sudo apt-get install -y inkscape
+     sudo apt-get install -y python-sphinx             \
+                             make                      \
+                             python-setuptools         \
+                             mscgen                    \
+                             graphviz                  \
+                             texlive                   \
+                             texlive-pictures          \
+                             texlive-latex-extra       \
+                             dvipng                    \
+                             texlive-fonts-recommended \
+                             poppler-utils             \
+                             inkscape                  \
+                             netpbm                    \
+                             unzip
+     # need netpbm for tikz
      sudo easy_install -U sphinxcontrib-mscgen
      sudo easy_install -U sphinxcontrib-tikz
-     # for tikz
-     sudo apt-get install netpbm
      # need standalone.cls that is not in texlive :-(
-     sudo -u vagrant wget  -q http://mirrors.ctan.org/install/macros/latex/contrib/standalone.tds.zip -O /tmp/standalone.tds.zip
-     sudo -u vagrant wget -q http://mirrors.ctan.org/macros/latex/contrib/titlesec.zip	-O /tmp/titlesec.zip
+     sudo -u vagrant wget -q http://mirrors.ctan.org/install/macros/latex/contrib/standalone.tds.zip -O /tmp/standalone.tds.zip
+     sudo -u vagrant wget -q http://mirrors.ctan.org/macros/latex/contrib/titlesec.zip -O /tmp/titlesec.zip
      sudo -u vagrant wget -q http://mirrors.ctan.org/macros/latex/contrib/wrapfig.zip -O /tmp/wrapfig.zip
+     sudo -u vagrant wget -q http://mirrors.ctan.org/macros/latex/contrib/multirow.zip -O /tmp/multirow.zip
      sudo mkdir /usr/share/texmf-texlive/tex/latex/needspace
      sudo wget -q http://ftp.rz.uni-wuerzburg.de/pub/tex/latex2e/contrib/misc/needspace.sty -O /usr/share/texmf-texlive/tex/latex/needspace/needspace.sty
-     sudo -u vagrant wget -q http://mirrors.ctan.org/macros/latex/contrib/multirow.zip -O /tmp/multirow.zip	
-     sudo apt-get install unzip
      sudo unzip -u /tmp/standalone.tds.zip -d /usr/share/texmf-texlive/tex/latex
      sudo unzip -u /tmp/titlesec.zip -d /usr/share/texmf-texlive/tex/latex
      sudo unzip -u /tmp/wrapfig.zip -d /usr/share/texmf-texlive/tex/latex

--- a/book-2nd/Makefile
+++ b/book-2nd/Makefile
@@ -15,11 +15,12 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
+.PHONY: help clean figures html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
 
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  figures    to make the figures required in all builds. This is a prerequisite!"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -138,3 +139,8 @@ pdf:
 	$(SPHINXBUILD) -b pdf $(ALLSPHINXOPTS) _build/pdf
 	@echo
 	@echo "Build finished. The PDF files are in _build/pdf."
+
+figures:
+	$(MAKE) -f Makefile-images
+	@echo
+	@echo "The figures have been built."

--- a/book-2nd/Makefile-images
+++ b/book-2nd/Makefile-images
@@ -1,9 +1,10 @@
 #
 # OB
 #
-DIRS = intro/svg intro/pkt application/svg application/pkt transport/pkt transport/svg network/pkt network/svg lan/pkt lan/svg
-SUBDIRS := $(addprefix ../book/, $(DIRS))
-  
+OLDDIRS = intro/svg intro/pkt application/svg application/pkt transport/pkt transport/svg network/pkt network/svg lan/pkt lan/svg
+SUBDIRS := $(addprefix ../book/, $(OLDDIRS))
+SUBDIRS += protocols/figures protocols/pkt
+
 subdirs:
 	for dir in $(SUBDIRS); do \
                $(MAKE) -C $$dir; \


### PR DESCRIPTION
Upon building from scratch, I realised that the old Makefile-images
forgets to build the new figures introduced in the transport chapter.
Update Makefile-images to fix this.
Add a new rule to Makefile `figures` to call Makefile-images from it.
Update Vagrantfile to run one single instance of apt-get install,
this slightly speed up the configuration of the vagrant box.
The duplication of install inkscape has also been removed.