### PR TITLE
Fix syntax errors in msc and tags

### DIFF
--- a/book-2nd/principles/security.rst
+++ b/book-2nd/principles/security.rst
@@ -688,7 +688,7 @@ the other's public key.
 
       a=>b [ label = "" ] ,
       b>>y [ label = "I'm Alice, key=Alice_{pub}", arcskip="1"];
-      y>>c [ label = "I'm Alice, key=Mallory_{pub}", color="red", arcskip="1"];
+      y>>c [ label = "I'm Alice, key=Mallory_{pub}", textcolour="red", linecolour="red", arcskip="1"];
       c=>d [ label = "" ];
 
       d=>c [ label = "" ] ,
@@ -697,7 +697,7 @@ the other's public key.
 
       a=>b [ label = "" ] ,
       b>>y [ label = "E_p(Alice_{priv},R)", arcskip="1"];
-      y>>c [ label = "E_p(Mallory_{priv},R)", color="red", arcskip="1"];
+      y>>c [ label = "E_p(Mallory_{priv},R)", textcolour="red", linecolour="red", arcskip="1"];
       c=>d [ label = "" ];
 
       d=>c [ label = "" ] ,
@@ -730,7 +730,7 @@ both have been authenticated.
       d [label="", linecolour=white];
 
       a=>b [ label = "" ] ,
-      b>>c [ label = I'm Alice", arcskip="1"];
+      b>>c [ label = "I'm Alice", arcskip="1"];
       c=>d [ label = "" ];
 
       d=>c [ label = "" ] ,

--- a/book-2nd/protocols/ssh.rst
+++ b/book-2nd/protocols/ssh.rst
@@ -25,7 +25,7 @@ telnet is the ASCII character set, but the extensions specified
 in :rfc:`5198` support the utilisation
 of Unicode characters.
 
-From a security viewpoint, the main drawback of :terme:`telnet` is that all
+From a security viewpoint, the main drawback of :term:`telnet` is that all
 the information, including the usernames, passwords and commands,
 is sent in cleartext over a TCP connection. This implies that
 an eavesdropper could easily capture the passwords used by anyone
@@ -45,7 +45,7 @@ similar protocols [Ylonen1996]_. :term:`ssh` became quickly popular and system
 administrators encouraged its usage. The original version of :term:`ssh`
 was freely available. After a few years, his author created a company
 to distribute it commercially, but other programmers continued to
-develop an open-source version of :term`ssh` called 
+develop an open-source version of :term:`ssh` called
 `OpenSSH <http://www.openssh.com>`_.
 Over the years, :term:`ssh` evolved
 and became a flexible applicable whose usage extends beyond remote


### PR DESCRIPTION
- MSC wouldn't let me generate some sequence charts.
- Typo in ssh tags