### PR TITLE
fixed conflicting positive responses in q6 from network-stp, fix for issue #244

### DIFF
--- a/book-2nd/mcq-ex/network-stp.rst
+++ b/book-2nd/mcq-ex/network-stp.rst
@@ -296,7 +296,7 @@ The third information contains two parts : the identifier of the switch that sen
 
       .. comment:: The BPDU of this switch is worse than the BPDU of switch ``6``. 
 
-   .. positive:: The port of switch ``6`` attached to the Hub is a blocked  port.
+   .. negative:: The port of switch ``6`` attached to the Hub is a blocked  port.
 
 
 


### PR DESCRIPTION
There are conflicting positive responses as indicated by @clementlinsmeau in question 6 from the MCQ of Ethernet networks .

Both 
`The port of switch 6 attached to the Hub is a blocked port.` and `The port of switch 6 attached to the Hub is a designated port.` cannot be true at the same time.